### PR TITLE
Add static program data and program card display

### DIFF
--- a/landingdodi/src/components/OfertaEducativa.jsx
+++ b/landingdodi/src/components/OfertaEducativa.jsx
@@ -1,22 +1,17 @@
 import React from 'react';
+import programas from '../data/programas';
+import ProgramaCard from './ProgramaCard';
 
 function OfertaEducativa() {
+  const programasActivos = programas.filter(p => p.estado === 'activo');
+
   return (
-    <section id="features" className="features">
-      <h2>Features</h2>
-      <div className="feature-grid">
-        <div className="feature-item">
-          <h3>Automation</h3>
-          <p>Automate your document workflows.</p>
-        </div>
-        <div className="feature-item">
-          <h3>Integration</h3>
-          <p>Connect with popular tools.</p>
-        </div>
-        <div className="feature-item">
-          <h3>Security</h3>
-          <p>Keep your data safe.</p>
-        </div>
+    <section id="oferta" className="oferta-educativa">
+      <h2>Nuestra oferta educativa</h2>
+      <div className="programas-grid">
+        {programasActivos.map(programa => (
+          <ProgramaCard key={programa.id} {...programa} />
+        ))}
       </div>
     </section>
   );

--- a/landingdodi/src/components/ProgramaCard.jsx
+++ b/landingdodi/src/components/ProgramaCard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function ProgramaCard({ nombre, modalidad, duracion, clases, inicio, descripcion, urlMasInfo }) {
+  return (
+    <div className="program-card">
+      <h3>{nombre}</h3>
+      <p><strong>Modalidad:</strong> {modalidad}</p>
+      <p><strong>Duración:</strong> {duracion}</p>
+      <p><strong>Clases:</strong> {clases}</p>
+      <p><strong>Inicio:</strong> {inicio}</p>
+      <p>{descripcion}</p>
+      <a href={urlMasInfo}>Conoce más</a>
+    </div>
+  );
+}
+
+export default ProgramaCard;

--- a/landingdodi/src/data/programas.js
+++ b/landingdodi/src/data/programas.js
@@ -1,0 +1,42 @@
+const programas = [
+  {
+    id: 'ddce',
+    nombre: 'Doctorado en Desarrollo de Competencias Docentes',
+    siglas: 'DDCE',
+    duracion: '2 años',
+    modalidad: '100% en línea',
+    clases: 'Jueves de 7:00 a 9:00 PM',
+    inicio: 'Agosto 2025',
+    estado: 'activo',
+    descripcion: 'Formación doctoral enfocada en el desarrollo profesional docente y la gestión de competencias para la educación del futuro.',
+    urlMasInfo: '/programas/ddce',
+    destacado: true,
+  },
+  {
+    id: 'melt',
+    nombre: 'Maestría en Educación con Énfasis en Liderazgo Transformacional',
+    siglas: 'MELT',
+    duracion: '1 año 4 meses',
+    modalidad: 'En línea, clases sabatinas',
+    clases: 'Sábados de 11:00 AM a 2:00 PM',
+    inicio: 'Agosto 2025',
+    estado: 'activo',
+    descripcion: 'Una maestría para líderes educativos que buscan transformar sus entornos desde la innovación, el liderazgo y la inteligencia digital.',
+    urlMasInfo: '/programas/melt',
+    destacado: true,
+  },
+  {
+    id: 'convive',
+    nombre: 'Congreso Virtual de Verano – CONVIVE',
+    duracion: '3 días',
+    modalidad: '100% en línea',
+    clases: '26, 27 y 28 de agosto',
+    inicio: 'Agosto 2025',
+    estado: 'activo',
+    descripcion: 'Evento internacional con expertos en IA, evaluación y transformación educativa. Grabaciones incluidas.',
+    urlMasInfo: '/eventos/convive',
+    destacado: false,
+  },
+];
+
+export default programas;


### PR DESCRIPTION
## Summary
- add `programas.js` with sample program data
- create `ProgramaCard` component for rendering program information
- update `OfertaEducativa` to list active programs using `ProgramaCard`

## Testing
- `npm test --silent --maxWorkers=50` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883fe85e334833096e6bae8d612aab1