### PR TITLE
Add header images and hero overlay with animations

### DIFF
--- a/landingdodi/package.json
+++ b/landingdodi/package.json
@@ -10,7 +10,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "framer-motion": "^11.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -28,12 +28,13 @@
 }
 
 .hero {
+  position: relative;
   background-color: var(--dodi-oscuro);
-  background-image: url('https://educrear.com.ar/archivost/id_354/colaborativo-foto-2.jpg');
   background-size: cover;
   background-position: center;
   color: white;
   padding: 4rem 1rem;
+  overflow: hidden;
 }
 
 .hero-content {

--- a/landingdodi/src/components/About.jsx
+++ b/landingdodi/src/components/About.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 
 function About() {
   return (
-    <section id="about" className="about">
+    <motion.section
+      id="about"
+      className="about"
+      initial={{ opacity: 0, y: 50 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      viewport={{ once: true }}
+    >
       <h2>¿Quiénes somos?</h2>
       <p>
         DoDi es una comunidad de docentes que aprende y crece con innovación digital y el poder de la inteligencia artificial. Evolucionamos desde DocencIA Digital para seguir conectando y formando educadores de todo el país.
       </p>
-    </section>
+    </motion.section>
   );
 }
 

--- a/landingdodi/src/components/Contacto.jsx
+++ b/landingdodi/src/components/Contacto.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 
 function Contacto() {
   return (
-    <section id="contact" className="contact">
+    <motion.section
+      id="contact"
+      className="contact"
+      initial={{ opacity: 0, y: 50 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      viewport={{ once: true }}
+    >
       <h2>Contact Us</h2>
       <form>
         <input type="text" placeholder="Your name" />
@@ -10,7 +18,7 @@ function Contacto() {
         <textarea placeholder="Message" />
         <button type="submit">Send</button>
       </form>
-    </section>
+    </motion.section>
   );
 }
 

--- a/landingdodi/src/components/Hero.jsx
+++ b/landingdodi/src/components/Hero.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 
 function Hero() {
   return (
-    <header className="hero">
-      <div className="hero-content">
+    <header
+      className="hero"
+      style={{
+        backgroundImage:
+          "url('https://educrear.com.ar/archivost/id_354/colaborativo-foto-2.jpg')",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      <div className="absolute inset-0 bg-[#043458]/70"></div>
+      <motion.div
+        className="hero-content relative z-10"
+        initial={{ opacity: 0, y: 30 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+        viewport={{ once: true }}
+      >
         <img
           src="https://i.ibb.co/n8DKbW4W/logo-1.png"
           alt="Logo de DoDi"
@@ -22,7 +38,7 @@ function Hero() {
           Comunidad, innovación e inteligencia artificial al servicio de los docentes.
         </p>
         <a className="cta-button" href="#contact">Únete a la comunidad</a>
-      </div>
+      </motion.div>
     </header>
   );
 }

--- a/landingdodi/src/components/OfertaEducativa.jsx
+++ b/landingdodi/src/components/OfertaEducativa.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import programas from '../data/programas';
 import ProgramaCard from './ProgramaCard';
 
@@ -6,14 +7,21 @@ function OfertaEducativa() {
   const programasActivos = programas.filter(p => p.estado === 'activo');
 
   return (
-    <section id="oferta" className="oferta-educativa">
+    <motion.section
+      id="oferta"
+      className="oferta-educativa"
+      initial={{ opacity: 0, y: 50 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+      viewport={{ once: true }}
+    >
       <h2>Nuestra oferta educativa</h2>
       <div className="programas-grid">
         {programasActivos.map(programa => (
           <ProgramaCard key={programa.id} {...programa} />
         ))}
       </div>
-    </section>
+    </motion.section>
   );
 }
 

--- a/landingdodi/src/components/ProgramaCard.jsx
+++ b/landingdodi/src/components/ProgramaCard.jsx
@@ -1,13 +1,37 @@
 import React from 'react';
 
-function ProgramaCard({ nombre, modalidad, duracion, clases, inicio, descripcion, urlMasInfo }) {
+function ProgramaCard({
+  nombre,
+  modalidad,
+  duracion,
+  clases,
+  inicio,
+  descripcion,
+  urlMasInfo,
+  imagenEncabezado,
+}) {
   return (
     <div className="program-card">
+      {imagenEncabezado && (
+        <img
+          src={imagenEncabezado}
+          alt={nombre}
+          className="w-full h-40 object-cover mb-4"
+        />
+      )}
       <h3>{nombre}</h3>
-      <p><strong>Modalidad:</strong> {modalidad}</p>
-      <p><strong>Duración:</strong> {duracion}</p>
-      <p><strong>Clases:</strong> {clases}</p>
-      <p><strong>Inicio:</strong> {inicio}</p>
+      <p>
+        <strong>Modalidad:</strong> {modalidad}
+      </p>
+      <p>
+        <strong>Duración:</strong> {duracion}
+      </p>
+      <p>
+        <strong>Clases:</strong> {clases}
+      </p>
+      <p>
+        <strong>Inicio:</strong> {inicio}
+      </p>
       <p>{descripcion}</p>
       <a href={urlMasInfo}>Conoce más</a>
     </div>

--- a/landingdodi/src/data/programas.js
+++ b/landingdodi/src/data/programas.js
@@ -3,6 +3,8 @@ const programas = [
     id: 'ddce',
     nombre: 'Doctorado en Desarrollo de Competencias Docentes',
     siglas: 'DDCE',
+    imagenEncabezado:
+      'https://images.unsplash.com/photo-1584697964190-1838171ade0a?auto=format&fit=crop&w=800&q=60',
     duracion: '2 años',
     modalidad: '100% en línea',
     clases: 'Jueves de 7:00 a 9:00 PM',
@@ -16,6 +18,8 @@ const programas = [
     id: 'melt',
     nombre: 'Maestría en Educación con Énfasis en Liderazgo Transformacional',
     siglas: 'MELT',
+    imagenEncabezado:
+      'https://images.unsplash.com/photo-1521790945508-bf2a36314e85?auto=format&fit=crop&w=800&q=60',
     duracion: '1 año 4 meses',
     modalidad: 'En línea, clases sabatinas',
     clases: 'Sábados de 11:00 AM a 2:00 PM',
@@ -28,6 +32,8 @@ const programas = [
   {
     id: 'convive',
     nombre: 'Congreso Virtual de Verano – CONVIVE',
+    imagenEncabezado:
+      'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=800&q=60',
     duracion: '3 días',
     modalidad: '100% en línea',
     clases: '26, 27 y 28 de agosto',


### PR DESCRIPTION
## Summary
- display a header image on each `ProgramaCard`
- include image URLs for each program entry
- update Hero with background image overlay and entrance animation
- animate main sections on scroll
- add Framer Motion dependency

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884077012948330a58f21790cf87fe3