### PR TITLE
Add footer copyright and WhatsApp button

### DIFF
--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -390,3 +390,55 @@
   display: inline-block;
   margin-bottom: 0.5rem;
 }
+
+.footer-copy {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #e5e7eb;
+}
+
+.whatsapp-button {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 50;
+}
+
+.whatsapp-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  background: #25D366;
+  border-radius: 50%;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s;
+}
+
+.whatsapp-link:hover {
+  transform: scale(1.1);
+}
+
+.whatsapp-tooltip {
+  position: absolute;
+  right: calc(100% + 0.5rem);
+  top: 50%;
+  transform: translateY(-50%) translateX(0.5rem);
+  background: #147da3;
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+.whatsapp-button:hover .whatsapp-tooltip {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+

--- a/landingdodi/src/App.jsx
+++ b/landingdodi/src/App.jsx
@@ -6,6 +6,7 @@ import OfertaEducativa from './components/OfertaEducativa';
 import Testimonios from './components/Testimonios';
 import Contacto from './components/Contacto';
 import Footer from './components/Footer';
+import WhatsappButton from './components/WhatsappButton';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
       <Testimonios />
       <Contacto />
       <Footer />
+      <WhatsappButton />
     </div>
   );
 }

--- a/landingdodi/src/components/Footer.jsx
+++ b/landingdodi/src/components/Footer.jsx
@@ -8,7 +8,7 @@ function Footer() {
         alt="DoDi"
         className="navbar-logo"
       />
-      <p>&copy; {new Date().getFullYear()} DoDi. All rights reserved.</p>
+      <p className="footer-copy">&copy; DoDi {new Date().getFullYear()}</p>
     </footer>
   );
 }

--- a/landingdodi/src/components/WhatsappButton.jsx
+++ b/landingdodi/src/components/WhatsappButton.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+function WhatsappButton() {
+  return (
+    <div className="whatsapp-button">
+      <a
+        href="https://wa.me/524498539586?text=Hola,%20tengo%20una%20duda%20sobre%20los%20programas%20de%20DoDi"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="whatsapp-link"
+        aria-label="Contáctanos por WhatsApp"
+      >
+        <img
+          src="https://icongr.am/fontawesome/whatsapp.svg?size=32&color=ffffff"
+          alt="WhatsApp"
+          className="whatsapp-icon"
+        />
+      </a>
+      <div className="whatsapp-tooltip">
+        ¿Tienes duda de algo? Contáctanos por WhatsApp
+      </div>
+    </div>
+  );
+}
+
+export default WhatsappButton;


### PR DESCRIPTION
## Summary
- enhance the footer with auto year text
- add a floating WhatsApp button component
- include styles for the WhatsApp button and footer copy

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841a7a09848330abab916bf522dde4