### PR TITLE
Improve About illustrations

### DIFF
--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -232,11 +232,19 @@
 
 .illustration-img {
   width: 100%;
-  max-width: 28rem;
-  border-radius: 0.75rem;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
-  margin: 2rem auto;
+  max-width: 40rem;
+  display: block;
+  margin: 3rem auto;
+  border-radius: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
   object-fit: cover;
+}
+
+.illustration-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 0;
 }
 
 .about-text {

--- a/landingdodi/src/components/About.jsx
+++ b/landingdodi/src/components/About.jsx
@@ -66,15 +66,17 @@ function About() {
         </motion.div>
       </div>
 
-      <motion.img
-        src="https://images.unsplash.com/photo-1581093588391-34efba5cd5a1?auto=format&fit=crop&w=800&q=60"
-        alt="Educación y tecnología"
-        className="illustration-img"
-        initial={{ opacity: 0, scale: 0.95 }}
-        whileInView={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
-      />
+      <div className="illustration-wrapper">
+        <motion.img
+          src="https://images.unsplash.com/photo-1581093588391-34efba5cd5a1?auto=format&fit=crop&w=800&q=60"
+          alt="Educación y tecnología"
+          className="illustration-img"
+          initial={{ opacity: 0, scale: 0.95 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6 }}
+          viewport={{ once: true }}
+        />
+      </div>
 
       <div className="about-grid">
         <motion.div
@@ -129,15 +131,17 @@ function About() {
         </motion.div>
       </div>
 
-      <motion.img
-        src="https://images.unsplash.com/photo-1551836022-b88bfb1411c7?auto=format&fit=crop&w=800&q=60"
-        alt="Congreso educativo"
-        className="illustration-img"
-        initial={{ opacity: 0, scale: 0.95 }}
-        whileInView={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.6 }}
-        viewport={{ once: true }}
-      />
+      <div className="illustration-wrapper">
+        <motion.img
+          src="https://images.unsplash.com/photo-1551836022-b88bfb1411c7?auto=format&fit=crop&w=800&q=60"
+          alt="Congreso educativo"
+          className="illustration-img"
+          initial={{ opacity: 0, scale: 0.95 }}
+          whileInView={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6 }}
+          viewport={{ once: true }}
+        />
+      </div>
     </motion.section>
   );
 }


### PR DESCRIPTION
## Summary
- improve visibility of `illustration-img` images with larger dimensions and stronger shadow
- add optional `illustration-wrapper` container for better layout
- wrap About section illustrations with the new container

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841d0fdff08330ba10948dcd354976