### PR TITLE
Add responsive promo button for mobile

### DIFF
--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -588,3 +588,62 @@
   color: var(--dodi-celeste);
 }
 
+.promo-float-button {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  .promo-banner {
+    display: none;
+  }
+
+  .promo-float-button {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .promo-float-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.5rem;
+    height: 3.5rem;
+    background: linear-gradient(to right, #147da3, #043458);
+    color: #fff;
+    border-radius: 50%;
+    font-size: 1.1rem;
+    font-weight: bold;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .promo-float-link:hover {
+    transform: scale(1.1);
+  }
+
+  .promo-tooltip {
+    margin-top: 0.5rem;
+    background: #147da3;
+    color: #fff;
+    padding: 0.35rem 0.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    transform: translateY(0.5rem);
+    transition: opacity 0.2s, transform 0.2s;
+  }
+
+  .promo-float-button:hover .promo-tooltip {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+

--- a/landingdodi/src/App.jsx
+++ b/landingdodi/src/App.jsx
@@ -7,6 +7,7 @@ import Testimonios from './components/Testimonios';
 import Contacto from './components/Contacto';
 import Footer from './components/Footer';
 import WhatsappButton from './components/WhatsappButton';
+import PromoFloatButton from './components/PromoFloatButton';
 import WaveDivider from './components/WaveDivider';
 import Loader from './components/Loader';
 import { AnimatePresence } from 'framer-motion';
@@ -31,6 +32,7 @@ function App() {
           <Contacto />
           <Footer />
           <WhatsappButton />
+          <PromoFloatButton />
         </div>
       )}
     </>

--- a/landingdodi/src/components/PromoFloatButton.jsx
+++ b/landingdodi/src/components/PromoFloatButton.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import promociones from '../data/promociones';
+
+function PromoFloatButton() {
+  const [promo, setPromo] = useState(null);
+
+  useEffect(() => {
+    const index = Math.floor(Math.random() * promociones.length);
+    setPromo(promociones[index]);
+  }, []);
+
+  if (!promo) return null;
+
+  return (
+    <div className="promo-float-button">
+      <a
+        href={promo.url}
+        className="promo-float-link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {promo.texto}
+      </a>
+      <div className="promo-tooltip">🎉 {promo.tooltip}</div>
+    </div>
+  );
+}
+
+export default PromoFloatButton;

--- a/landingdodi/src/data/promociones.js
+++ b/landingdodi/src/data/promociones.js
@@ -1,0 +1,24 @@
+const promociones = [
+  {
+    texto: '🎁 Julio50',
+    tooltip: 'Usa tu código de $50 en tienda',
+    url: 'https://tu-tienda.com',
+  },
+  {
+    texto: '🎓 Julio100',
+    tooltip: 'Descuento de $100 en la Maestría',
+    url: 'https://wa.me/524498539586?text=Quiero%20usar%20el%20c%C3%B3digo%20Julio100',
+  },
+  {
+    texto: '📚 JulioMaster',
+    tooltip: 'Descuento en tu próxima masterclass',
+    url: 'https://wa.me/524498539586?text=Quiero%20usar%20el%20c%C3%B3digo%20Julio50%20para%20mi%20masterclass',
+  },
+  {
+    texto: '🎓 Julio150',
+    tooltip: 'Ahorra $150 en el Doctorado',
+    url: 'https://wa.me/524498539586?text=Quiero%20usar%20el%20c%C3%B3digo%20Julio150',
+  },
+];
+
+export default promociones;


### PR DESCRIPTION
## Summary
- add floating promo button for small screens
- hide banner on mobile and show floating promo button instead
- expose promo list data

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688420c1460c8330b31d7ecd9c970f24