### PR TITLE
Improve DoDi layout background and cards

### DIFF
--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -188,6 +188,7 @@
 
 .features {
   padding: 4rem 1rem;
+  background-color: #ffffff;
 }
 
 .feature-grid {
@@ -203,11 +204,19 @@
   padding: 1rem;
   border-radius: 4px;
   width: 200px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  border-left: 4px solid #147da3;
+  transition: all 0.3s ease-in-out;
 }
 
-.about,
+.about {
+  padding: 4rem 1rem;
+  background-color: #e9eef3;
+}
+
 .contact {
   padding: 4rem 1rem;
+  background-color: #ffffff;
 }
 
 .extended-about h2 {
@@ -277,10 +286,12 @@
   backdrop-filter: blur(6px);
   padding: 2rem;
   border-radius: 1rem;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   max-width: 40rem;
   margin: 0 auto;
   text-align: center;
+  transition: all 0.3s ease-in-out;
+  border-left: 4px solid #147da3;
 }
 
 .contact-intro {
@@ -311,10 +322,7 @@
   color: #fff;
   border-radius: 0.5rem;
   cursor: pointer;
-  transition:
-    background 0.2s,
-    transform 0.2s,
-    box-shadow 0.2s;
+  transition: all 0.3s ease-in-out;
 }
 
 .contact button:hover {
@@ -408,6 +416,11 @@
   gap: 1.5rem;
 }
 
+.testimonios-section {
+  background-color: #e9eef3;
+  padding: 4rem 1rem;
+}
+
 @media (min-width: 768px) {
   .testimonio-grid {
     grid-template-columns: repeat(2, 1fr);
@@ -426,10 +439,11 @@
   backdrop-filter: blur(6px);
   color: #043458;
   border-radius: 1.25rem;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   padding: 2rem;
   text-align: left;
   transition: all 0.3s ease-in-out;
+  border-left: 4px solid #147da3;
 }
 
 .testimonio-card:hover {
@@ -482,10 +496,11 @@
   background: rgba(255, 255, 255, 0.9);
   color: #043458;
   border-radius: 1rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   padding: 1.5rem;
   text-align: left;
   transition: all 0.3s ease-in-out;
+  border-left: 4px solid #147da3;
 }
 
 .program-card:hover {

--- a/landingdodi/src/index.css
+++ b/landingdodi/src/index.css
@@ -14,6 +14,10 @@ body {
   font-family: 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f0f4f8;
+  background-image: url('https://www.toptal.com/designers/subtlepatterns/patterns/symphony.png');
+  background-repeat: repeat;
+  background-size: auto;
 }
 
 h1,
@@ -23,6 +27,11 @@ h4,
 h5,
 h6 {
   font-family: 'Inter', sans-serif;
+}
+
+h2 {
+  border-left: 6px solid #147da3;
+  padding-left: 0.75rem;
 }
 
 code {


### PR DESCRIPTION
## Summary
- soften overall background and add subtle texture
- alternate section colors for better rhythm
- accent headings and cards with brand border
- add smooth transitions across interactive elements

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842147de5c8330b562f3256b48e573