### PR TITLE
Integrate Formspree and add thank you page

### DIFF
--- a/landingdodi/package.json
+++ b/landingdodi/package.json
@@ -12,7 +12,8 @@
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4",
-    "framer-motion": "^10.16.4"
+    "framer-motion": "^10.16.4",
+    "react-router-dom": "^6.23.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -662,3 +662,16 @@
   }
 }
 
+
+.gracias-page {
+  padding: 4rem 1rem;
+  min-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.gracias-page h2 {
+  color: var(--dodi-oscuro);
+}

--- a/landingdodi/src/components/Contacto.jsx
+++ b/landingdodi/src/components/Contacto.jsx
@@ -23,9 +23,10 @@ function Contacto() {
           contigo para darte atención personalizada.
         </p>
         <form
-          action="https://formsubmit.co/cesar.velasquez.rios@gmail.com"
+          action="https://formspree.io/f/xyznm789"
           method="POST"
         >
+          <input type="hidden" name="_redirect" value="/gracias" />
           <input
             type="text"
             name="nombre"

--- a/landingdodi/src/components/Gracias.jsx
+++ b/landingdodi/src/components/Gracias.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+function Gracias() {
+  return (
+    <motion.section
+      className="gracias-page"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6 }}
+    >
+      <h2>✅ ¡Gracias por contactarnos!</h2>
+      <p>
+        Pronto uno de nuestros asesores se pondrá en contacto contigo por
+        WhatsApp o correo electrónico.
+      </p>
+      <p>
+        📲 Si deseas atención inmediata,
+        <a
+          href="https://wa.me/524498539586"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          haz clic aquí para escribirnos por WhatsApp
+        </a>
+        .
+      </p>
+    </motion.section>
+  );
+}
+
+export default Gracias;

--- a/landingdodi/src/index.js
+++ b/landingdodi/src/index.js
@@ -2,13 +2,20 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import Gracias from './components/Gracias';
 import reportWebVitals from './reportWebVitals';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/gracias" element={<Gracias />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- update contact form to send data to Formspree and redirect to `/gracias`
- add new `Gracias` page with short message and WhatsApp link
- wire up React Router and route `/gracias`
- style the new page
- add `react-router-dom` dependency

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842461abe0833088e0ec809609fea6