### PR TITLE
Add informational modals for education programs

### DIFF
--- a/landingdodi/src/App.css
+++ b/landingdodi/src/App.css
@@ -675,3 +675,66 @@
 .gracias-page h2 {
   color: var(--dodi-oscuro);
 }
+
+/* Modal styles */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.modal-content {
+  background: #fff;
+  color: #043458;
+  border-radius: 1rem;
+  padding: 2rem;
+  width: 90%;
+  max-width: 600px;
+  position: relative;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #043458;
+}
+
+.modal-body {
+  margin-top: 1rem;
+  line-height: 1.5;
+}
+
+.modal-cta {
+  display: block;
+  margin-top: 1.5rem;
+  background: #25D366;
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+  text-align: center;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.modal-cta:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+@media (min-width: 640px) {
+  .modal-cta {
+    width: auto;
+    display: inline-block;
+  }
+}

--- a/landingdodi/src/components/Modal.jsx
+++ b/landingdodi/src/components/Modal.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+function Modal({ open, onClose, title, children, ctaText, ctaUrl }) {
+  const modalRef = useRef(null);
+  const closeBtnRef = useRef(null);
+
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Tab') {
+        const focusable = modalRef.current.querySelectorAll(
+          'a[href], button:not([disabled]), textarea, input, select'
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      }
+    }
+
+    if (open) {
+      document.body.style.overflow = 'hidden';
+      closeBtnRef.current?.focus();
+      document.addEventListener('keydown', handleKeyDown);
+    }
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="modal-overlay"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <motion.div
+          className="modal-content"
+          ref={modalRef}
+          initial={{ opacity: 0, y: 50 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 50 }}
+          transition={{ duration: 0.3 }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-title"
+        >
+          <button
+            ref={closeBtnRef}
+            className="modal-close"
+            onClick={onClose}
+            aria-label="Cerrar modal"
+          >
+            \u2715
+          </button>
+          <h3 id="modal-title">{title}</h3>
+          <div className="modal-body">{children}</div>
+          <a
+            href={ctaUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="modal-cta"
+          >
+            {ctaText}
+          </a>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+export default Modal;

--- a/landingdodi/src/components/ProgramaCard.jsx
+++ b/landingdodi/src/components/ProgramaCard.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Modal from './Modal';
 
 function ProgramaCard({
   id,
@@ -9,40 +10,87 @@ function ProgramaCard({
   clases,
   inicio,
   descripcion,
-  urlMasInfo,
+  detalle,
   imagenEncabezado,
 }) {
+  const [open, setOpen] = useState(false);
   let categoria = 'Congreso';
   if (id && id.includes('melt')) {
     categoria = 'Maestría';
   } else if (id && id.includes('ddce')) {
     categoria = 'Doctorado';
   }
+
+  let ctaText = '';
+  let ctaUrl = '';
+  if (id === 'ddce') {
+    ctaText = 'Inscribirme al Doctorado (DDCE)';
+    ctaUrl =
+      'https://wa.me/524498539586?text=Hola, me interesa inscribirme al Doctorado DDCE y quiero más información.';
+  } else if (id === 'melt') {
+    ctaText = 'Inscribirme a la Maestría MELT';
+    ctaUrl =
+      'https://wa.me/524498539586?text=Hola, me interesa inscribirme a la Maestría MELT y quiero más información.';
+  } else {
+    ctaText = 'Inscribirme al Congreso CONVIVE 2025';
+    ctaUrl =
+      'https://wa.me/524498539586?text=Hola, me interesa participar en el Congreso CONVIVE 2025 y quiero más información.';
+  }
   return (
-    <motion.div
-      className="program-card"
-      initial={{ opacity: 0, y: -20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6 }}
-      viewport={{ once: true }}
-    >
-      <div className="program-category">{categoria}</div>
-      <h3>{nombre}</h3>
-      <p>
-        <strong>Modalidad:</strong> {modalidad}
-      </p>
-      <p>
-        <strong>Duración:</strong> {duracion}
-      </p>
-      <p>
-        <strong>Clases:</strong> {clases}
-      </p>
-      <p>
-        <strong>Inicio:</strong> {inicio}
-      </p>
-      <p>{descripcion}</p>
-      <a href={urlMasInfo}>Conoce más</a>
-    </motion.div>
+    <>
+      <motion.div
+        className="program-card"
+        initial={{ opacity: 0, y: -20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        viewport={{ once: true }}
+        role="button"
+        tabIndex={0}
+        onClick={() => setOpen(true)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') setOpen(true);
+        }}
+      >
+        <div className="program-category">{categoria}</div>
+        <h3>{nombre}</h3>
+        <p>
+          <strong>Modalidad:</strong> {modalidad}
+        </p>
+        <p>
+          <strong>Duración:</strong> {duracion}
+        </p>
+        <p>
+          <strong>Clases:</strong> {clases}
+        </p>
+        <p>
+          <strong>Inicio:</strong> {inicio}
+        </p>
+        <p>{descripcion}</p>
+        <button
+          type="button"
+          className="secondary-button"
+          onClick={e => {
+            e.stopPropagation();
+            setOpen(true);
+          }}
+        >
+          Conoce más
+        </button>
+      </motion.div>
+      <AnimatePresence>
+        {open && (
+          <Modal
+            open={open}
+            onClose={() => setOpen(false)}
+            title={nombre}
+            ctaText={ctaText}
+            ctaUrl={ctaUrl}
+          >
+            <p>{detalle}</p>
+          </Modal>
+        )}
+      </AnimatePresence>
+    </>
   );
 }
 

--- a/landingdodi/src/data/programas.js
+++ b/landingdodi/src/data/programas.js
@@ -11,6 +11,8 @@ const programas = [
     inicio: 'Agosto 2025',
     estado: 'activo',
     descripcion: 'Formación doctoral enfocada en el desarrollo profesional docente y la gestión de competencias para la educación del futuro.',
+    detalle:
+      'Formación doctoral que profundiza en la planeación y desarrollo de estrategias docentes basadas en competencias. A lo largo del programa se abordan tendencias de innovación educativa, liderazgo académico y uso de tecnologías emergentes para transformar el aprendizaje. Está dirigido a profesionales interesados en potenciar su carrera con un enfoque de investigación aplicada.',
     urlMasInfo: '/programas/ddce',
     destacado: true,
   },
@@ -26,6 +28,8 @@ const programas = [
     inicio: 'Agosto 2025',
     estado: 'activo',
     descripcion: 'Una maestría para líderes educativos que buscan transformar sus entornos desde la innovación, el liderazgo y la inteligencia digital.',
+    detalle:
+      'La Maestría MELT prepara líderes capaces de impulsar la transformación escolar mediante la integración de competencias digitales, liderazgo colaborativo y estrategias de evaluación auténtica. Sus módulos se imparten por especialistas en línea y permiten aplicar de inmediato lo aprendido en el contexto laboral. Ideal para docentes y coordinadores que buscan impactar su comunidad.',
     urlMasInfo: '/programas/melt',
     destacado: true,
   },
@@ -40,6 +44,8 @@ const programas = [
     inicio: 'Agosto 2025',
     estado: 'activo',
     descripcion: 'Evento internacional con expertos en IA, evaluación y transformación educativa. Grabaciones incluidas.',
+    detalle:
+      'CONVIVE 2025 es un congreso virtual que reúne a expertos nacionales e internacionales en temas de inteligencia artificial, evaluación por competencias y gestión del cambio educativo. Durante tres días disfrutarás de conferencias magistrales y paneles interactivos desde la comodidad de tu casa. Las grabaciones permanecerán disponibles para que repases cada sesión.',
     urlMasInfo: '/eventos/convive',
     destacado: false,
   },


### PR DESCRIPTION
## Summary
- add `Modal` component with focus trap and animations
- include long descriptions in `programas.js`
- update `ProgramaCard` to open modal with extended info and WhatsApp CTA
- add modal styling

## Testing
- `npm test -- -u --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6884272847e08330b2464bc051dcff7d