### PR TITLE
Update DDCE and MELT modals

### DIFF
--- a/landingdodi/src/components/Modal.jsx
+++ b/landingdodi/src/components/Modal.jsx
@@ -67,16 +67,18 @@ function Modal({ open, onClose, title, children, ctaText, ctaUrl }) {
           >
             \u2715
           </button>
-          <h3 id="modal-title">{title}</h3>
+          {title && <h3 id="modal-title">{title}</h3>}
           <div className="modal-body">{children}</div>
-          <a
-            href={ctaUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="modal-cta"
-          >
-            {ctaText}
-          </a>
+          {ctaText && ctaUrl && (
+            <a
+              href={ctaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="modal-cta"
+            >
+              {ctaText}
+            </a>
+          )}
         </motion.div>
       </motion.div>
     </AnimatePresence>

--- a/landingdodi/src/components/ProgramaCard.jsx
+++ b/landingdodi/src/components/ProgramaCard.jsx
@@ -21,20 +21,77 @@ function ProgramaCard({
     categoria = 'Doctorado';
   }
 
-  let ctaText = '';
-  let ctaUrl = '';
-  if (id === 'ddce') {
-    ctaText = 'Inscribirme al Doctorado (DDCE)';
-    ctaUrl =
-      'https://wa.me/524498539586?text=Hola, me interesa inscribirme al Doctorado DDCE y quiero más información.';
-  } else if (id === 'melt') {
-    ctaText = 'Inscribirme a la Maestría MELT';
-    ctaUrl =
-      'https://wa.me/524498539586?text=Hola, me interesa inscribirme a la Maestría MELT y quiero más información.';
-  } else {
+  let ctaText = null;
+  let ctaUrl = null;
+  if (id === 'convive') {
     ctaText = 'Inscribirme al Congreso CONVIVE 2025';
     ctaUrl =
       'https://wa.me/524498539586?text=Hola, me interesa participar en el Congreso CONVIVE 2025 y quiero más información.';
+  }
+
+  let modalContent = <p>{detalle}</p>;
+
+  if (id === 'ddce') {
+    modalContent = (
+      <>
+        <h2 className="text-xl font-bold text-center mb-2">
+          Doctorado en Desarrollo de Competencias Educativas (DDCE)
+        </h2>
+        <p className="mb-2">
+          🎓 Forma parte de la Generación 25 del DDCE — diseñado para transformar la educación desde las aulas y comunidades.
+        </p>
+        <ul className="list-disc list-inside text-left mb-4">
+          <li>✅ Duración: 2 años</li>
+          <li>📅 Clases por Zoom: martes de 7:00 a 9:00 p.m.</li>
+          <li>💼 Carga horaria ligera: ideal para personas que trabajan</li>
+          <li>💻 Plataforma de tareas: Google Classroom</li>
+          <li>🧠 Formación continua: acceso gratuito a masterclasses y congresos sobre IA y tecnología educativa</li>
+          <li>🧾 RVOE Federal válido para USICAMM</li>
+          <li>💲 Inscripción: $1,000 MXN</li>
+          <li>💵 Mensualidad fija: $1,800 MXN</li>
+          <li>📜 Titulación por tesis: $20,000 MXN</li>
+        </ul>
+        <a
+          href="https://wa.me/524498539586?text=Hola%2C%20me%20interesa%20inscribirme%20al%20Doctorado%20DDCE"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn w-full mt-2"
+        >
+          ¡Quiero más información por WhatsApp!
+        </a>
+      </>
+    );
+  } else if (id === 'melt') {
+    modalContent = (
+      <>
+        <h2 className="text-xl font-bold text-center mb-2">
+          Maestría en Liderazgo Transformacional (MELT)
+        </h2>
+        <p className="mb-2">
+          🎓 Una opción ideal para quienes desean liderar el cambio en sus instituciones educativas desde una visión innovadora.
+        </p>
+        <ul className="list-disc list-inside text-left mb-4">
+          <li>✅ Duración: 1 año 4 meses</li>
+          <li>📅 Clases por Zoom: sábados de 11:00 a.m. a 2:00 p.m.</li>
+          <li>💼 Carga ligera: pensada para personas que trabajan</li>
+          <li>💻 Plataforma de tareas: Google Classroom</li>
+          <li>🧠 Acceso gratuito a masterclasses y congresos en IA y tecnología educativa</li>
+          <li>🧾 RVOE Federal válido para USICAMM</li>
+          <li>💲 Inscripción inicial: $400 MXN</li>
+          <li>💲 Inscripción tercer cuatrimestre: $4,000 MXN</li>
+          <li>💵 Mensualidad fija: $1,400 MXN</li>
+          <li>📜 Titulación por tesis: $18,000 MXN</li>
+        </ul>
+        <a
+          href="https://wa.me/524498539586?text=Hola%2C%20me%20interesa%20inscribirme%20a%20la%20Maestr%C3%ADa%20MELT"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn w-full mt-2"
+        >
+          ¡Quiero más información por WhatsApp!
+        </a>
+      </>
+    );
   }
   return (
     <>
@@ -82,11 +139,11 @@ function ProgramaCard({
           <Modal
             open={open}
             onClose={() => setOpen(false)}
-            title={nombre}
+            title={id === 'convive' ? nombre : ''}
             ctaText={ctaText}
             ctaUrl={ctaUrl}
           >
-            <p>{detalle}</p>
+            {modalContent}
           </Modal>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- adjust `Modal` component to only show the CTA link and title when provided
- extend DDCE and MELT modal content in `ProgramaCard`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884299260a083309d64f480fc606852